### PR TITLE
Count total requests and errors for http endpoints

### DIFF
--- a/processors/http_start_stop_processor_test.go
+++ b/processors/http_start_stop_processor_test.go
@@ -44,7 +44,7 @@ var _ = Describe("HttpStartStopProcessor", func() {
 		It("returns a Metric for each of the ProcessHttpStartStop* methods", func() {
 			processedMetrics := processor.Process(event)
 
-			Expect(processedMetrics).To(HaveLen(2))
+			Expect(processedMetrics).To(HaveLen(4))
 		})
 	})
 
@@ -69,6 +69,18 @@ var _ = Describe("HttpStartStopProcessor", func() {
 
 				Expect(metric.Stat).To(Equal("http.statuscodes.api_10_244_0_34_xip_io.200"))
 			})
+
+			It("it does not increment the error counter by one", func() {
+				metric := processor.ProcessHttpStartStopHttpErrorCount(httpStartStopEvent)
+				Expect(metric.Stat).To(Equal("http.errors.api_10_244_0_34_xip_io"))
+				Expect(metric.Value).To(Equal(int64(0)))
+			})
+
+			It("increments the requests counter by one", func() {
+				metric := processor.ProcessHttpStartStopHttpRequestCount(httpStartStopEvent)
+				Expect(metric.Stat).To(Equal("http.requests.api_10_244_0_34_xip_io"))
+				Expect(metric.Value).To(Equal(int64(1)))
+			})
 		})
 
 		Context("with a HTTP 404 status code", func() {
@@ -78,6 +90,22 @@ var _ = Describe("HttpStartStopProcessor", func() {
 				metric := processor.ProcessHttpStartStopStatusCodeCount(httpStartStopEvent)
 
 				Expect(metric.Stat).To(Equal("http.statuscodes.api_10_244_0_34_xip_io.404"))
+			})
+
+			It("increments the error counter by one", func() {
+				statusCode := int32(404)
+				httpStartStopEvent.StatusCode = &statusCode
+				metric := processor.ProcessHttpStartStopHttpErrorCount(httpStartStopEvent)
+				Expect(metric.Stat).To(Equal("http.errors.api_10_244_0_34_xip_io"))
+				Expect(metric.Value).To(Equal(int64(1)))
+			})
+
+			It("increments the requests counter by one", func() {
+				statusCode := int32(404)
+				httpStartStopEvent.StatusCode = &statusCode
+				metric := processor.ProcessHttpStartStopHttpRequestCount(httpStartStopEvent)
+				Expect(metric.Stat).To(Equal("http.requests.api_10_244_0_34_xip_io"))
+				Expect(metric.Value).To(Equal(int64(1)))
 			})
 		})
 
@@ -98,5 +126,6 @@ var _ = Describe("HttpStartStopProcessor", func() {
 				Expect(metric.Value).To(Equal(int64(0)))
 			})
 		})
+
 	})
 })

--- a/sample/main.go
+++ b/sample/main.go
@@ -17,7 +17,7 @@ import (
 
 const DopplerAddress = "wss://doppler.10.244.0.34.xip.io:443"
 const firehoseSubscriptionId = "firehose-a"
-const statsdAddress = "10.244.11.2:8125"
+const statsdAddress = "10.244.2.2:8125"
 const statsdPrefix = "mycf."
 
 var authToken = os.Getenv("CF_ACCESS_TOKEN")


### PR DESCRIPTION
Hi! 
I really dig the sample nozzle, thank you so much! Saved me a ton of time to start pumping data into StatsD. I felt like i was working just a bit too hard to paint a simple dashboard and added two basic metrics for all http endpoints. Total requests and errors. Is this something you would be interested in having in the sample?

![apirequestsanderrors](https://cloud.githubusercontent.com/assets/414409/7789083/9b30c5a8-0219-11e5-81b8-655e4882940c.png)
