### PR TITLE
Gather additional metrics: total requests and errors per http endpoint

### DIFF
--- a/processors/http_start_stop_processor.go
+++ b/processors/http_start_stop_processor.go
@@ -15,11 +15,13 @@ func NewHttpStartStopProcessor() *HttpStartStopProcessor {
 }
 
 func (p *HttpStartStopProcessor) Process(e *events.Envelope) []metrics.Metric {
-	processedMetrics := make([]metrics.Metric, 2)
+	processedMetrics := make([]metrics.Metric, 4)
 	httpStartStopEvent := e.GetHttpStartStop()
 
 	processedMetrics[0] = metrics.Metric(p.ProcessHttpStartStopResponseTime(httpStartStopEvent))
 	processedMetrics[1] = metrics.Metric(p.ProcessHttpStartStopStatusCodeCount(httpStartStopEvent))
+	processedMetrics[2] = metrics.Metric(p.ProcessHttpStartStopHttpErrorCount(httpStartStopEvent))
+	processedMetrics[3] = metrics.Metric(p.ProcessHttpStartStopHttpRequestCount(httpStartStopEvent))
 
 	return processedMetrics
 }
@@ -39,13 +41,23 @@ func (p *HttpStartStopProcessor) ProcessHttpStartStopResponseTime(event *events.
 }
 
 func (p *HttpStartStopProcessor) ProcessHttpStartStopStatusCodeCount(event *events.HttpStartStop) *metrics.CounterMetric {
-	var incrementValue int64
-
 	statPrefix := "http.statuscodes."
 	hostname := strings.Replace(strings.Split(event.GetUri(), "/")[0], ".", "_", -1)
 	stat := statPrefix + hostname + "." + strconv.Itoa(int(event.GetStatusCode()))
 
-	if event.GetPeerType() == events.PeerType_Client {
+	metric := metrics.NewCounterMetric(stat, isPeer(event))
+
+	return metric
+}
+
+func (p *HttpStartStopProcessor) ProcessHttpStartStopHttpErrorCount(event *events.HttpStartStop) *metrics.CounterMetric {
+	var incrementValue int64
+
+	statPrefix := "http.errors."
+	hostname := strings.Replace(strings.Split(event.GetUri(), "/")[0], ".", "_", -1)
+	stat := statPrefix + hostname
+
+	if 299 < event.GetStatusCode() && 1 == isPeer(event) {
 		incrementValue = 1
 	} else {
 		incrementValue = 0
@@ -54,4 +66,21 @@ func (p *HttpStartStopProcessor) ProcessHttpStartStopStatusCodeCount(event *even
 	metric := metrics.NewCounterMetric(stat, incrementValue)
 
 	return metric
+}
+
+func (p *HttpStartStopProcessor) ProcessHttpStartStopHttpRequestCount(event *events.HttpStartStop) *metrics.CounterMetric {
+	statPrefix := "http.requests."
+	hostname := strings.Replace(strings.Split(event.GetUri(), "/")[0], ".", "_", -1)
+	stat := statPrefix + hostname
+	metric := metrics.NewCounterMetric(stat, isPeer(event))
+
+	return metric
+}
+
+func isPeer(event *events.HttpStartStop) int64 {
+	if event.GetPeerType() == events.PeerType_Client {
+		return 1
+	} else {
+		return 0
+	}
 }

--- a/processors/http_start_stop_processor_test.go
+++ b/processors/http_start_stop_processor_test.go
@@ -44,7 +44,7 @@ var _ = Describe("HttpStartStopProcessor", func() {
 		It("returns a Metric for each of the ProcessHttpStartStop* methods", func() {
 			processedMetrics := processor.Process(event)
 
-			Expect(processedMetrics).To(HaveLen(2))
+			Expect(processedMetrics).To(HaveLen(4))
 		})
 	})
 
@@ -69,6 +69,18 @@ var _ = Describe("HttpStartStopProcessor", func() {
 
 				Expect(metric.Stat).To(Equal("http.statuscodes.api_10_244_0_34_xip_io.200"))
 			})
+
+			It("it does not increment the error counter by one", func() {
+				metric := processor.ProcessHttpStartStopHttpErrorCount(httpStartStopEvent)
+				Expect(metric.Stat).To(Equal("http.errors.api_10_244_0_34_xip_io"))
+				Expect(metric.Value).To(Equal(int64(0)))
+			})
+
+			It("increments the requests counter by one", func() {
+				metric := processor.ProcessHttpStartStopHttpRequestCount(httpStartStopEvent)
+				Expect(metric.Stat).To(Equal("http.requests.api_10_244_0_34_xip_io"))
+				Expect(metric.Value).To(Equal(int64(1)))
+			})
 		})
 
 		Context("with a HTTP 404 status code", func() {
@@ -78,6 +90,22 @@ var _ = Describe("HttpStartStopProcessor", func() {
 				metric := processor.ProcessHttpStartStopStatusCodeCount(httpStartStopEvent)
 
 				Expect(metric.Stat).To(Equal("http.statuscodes.api_10_244_0_34_xip_io.404"))
+			})
+
+			It("increments the error counter by one", func() {
+				statusCode := int32(404)
+				httpStartStopEvent.StatusCode = &statusCode
+				metric := processor.ProcessHttpStartStopHttpErrorCount(httpStartStopEvent)
+				Expect(metric.Stat).To(Equal("http.errors.api_10_244_0_34_xip_io"))
+				Expect(metric.Value).To(Equal(int64(1)))
+			})
+
+			It("increments the requests counter by one", func() {
+				statusCode := int32(404)
+				httpStartStopEvent.StatusCode = &statusCode
+				metric := processor.ProcessHttpStartStopHttpRequestCount(httpStartStopEvent)
+				Expect(metric.Stat).To(Equal("http.requests.api_10_244_0_34_xip_io"))
+				Expect(metric.Value).To(Equal(int64(1)))
 			})
 		})
 
@@ -98,5 +126,6 @@ var _ = Describe("HttpStartStopProcessor", func() {
 				Expect(metric.Value).To(Equal(int64(0)))
 			})
 		})
+
 	})
 })

--- a/sample/main.go
+++ b/sample/main.go
@@ -17,7 +17,7 @@ import (
 
 const DopplerAddress = "wss://doppler.10.244.0.34.xip.io:443"
 const firehoseSubscriptionId = "firehose-a"
-const statsdAddress = "10.244.2.2:8125"
+const statsdAddress = "10.244.11.2:8125"
 const statsdPrefix = "mycf."
 
 var authToken = os.Getenv("CF_ACCESS_TOKEN")

--- a/sample/main.go
+++ b/sample/main.go
@@ -17,7 +17,7 @@ import (
 
 const DopplerAddress = "wss://doppler.10.244.0.34.xip.io:443"
 const firehoseSubscriptionId = "firehose-a"
-const statsdAddress = "10.244.11.2:8125"
+const statsdAddress = "10.244.2.2:8125"
 const statsdPrefix = "mycf."
 
 var authToken = os.Getenv("CF_ACCESS_TOKEN")


### PR DESCRIPTION
Hi! 
I really dig the sample nozzle, thank you so much! Saved me a ton of time to start pumping data into StatsD. I felt like i was working just a bit too hard to paint a simple dashboard and added two basic metrics for all http endpoints. Total requests and errors. Is this something you would be interested in having in the sample?

![apirequestsanderrors](https://cloud.githubusercontent.com/assets/414409/7789233/2ab140c2-021f-11e5-864b-a5c4219b4784.png)

I also had to roll the IP address for statsd back 10.244.2.2 when using the CloudCredo statsd/graphite bosh release. This was with a fresh bosh-lite head on the statsd release. 