### PR TITLE
Update with client id and secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library consumes events off the Cloud Foundry Firehose, processes them, and
 
 ## Getting Started
 
-* A user who has access to the Cloud Foundry Firehose configured in
+* A client id and secret that has access to the Cloud Foundry Firehose configured in
 your manifest
 
 ```
@@ -15,12 +15,21 @@ properties:
         access-token-validity: 1209600
         authorized-grant-types: authorization_code,client_credentials,refresh_token
         override: true
-        secret: <password>
+        secret: <secret>
         scope: openid,oauth.approvals,doppler.firehose
         authorities: oauth.login,doppler.firehose
 
 ```
-
+or alternately configured via the uaac cli:
+```
+uaac target https://uaa.[your cf system domain] --skip-ssl-validation
+uaac token client get admin -s [your admin-secret]
+uaac client add graphite-nozzle \
+      --name firehose-to-syslog \
+      --secret [your_client_secret] \
+      --authorized_grant_types client_credentials,refresh_token \
+      --authorities doppler.firehose
+```
 * A Graphite and StatsD server (see [here](https://github.com/CloudCredo/graphite-statsd-boshrelease) for a Graphite/StatsD BOSH release).
 * Golang installed and configured (see [here](https://golang.org/doc/install) for a tutorial on how to do this).
 * godep (see [here](https://github.com/tools/godep) for installation instructions).

--- a/main.go
+++ b/main.go
@@ -25,8 +25,10 @@ var (
 	statsdPrefix      = kingpin.Flag("statsd-prefix", "Statsd prefix").Default("mycf.").OverrideDefaultFromEnvar("STATSD_PREFIX").String()
 	statsdProtocol      = kingpin.Flag("statsd-protocol", "Statsd protocol, either udp or tcp").Default("udp").OverrideDefaultFromEnvar("STATSD_PROTOCOL").String()
 	prefixJob         = kingpin.Flag("prefix-job", "Prefix metric names with job.index").Default("false").OverrideDefaultFromEnvar("PREFIX_JOB").Bool()
-	username          = kingpin.Flag("username", "Firehose username.").Default("admin").OverrideDefaultFromEnvar("FIREHOSE_USERNAME").String()
-	password          = kingpin.Flag("password", "Firehose password.").Default("admin").OverrideDefaultFromEnvar("FIREHOSE_PASSWORD").String()
+	username          = kingpin.Flag("username", "Firehose client id [deprecated]. Use client-id").Default("admin").OverrideDefaultFromEnvar("FIREHOSE_USERNAME").String()
+	password          = kingpin.Flag("password", "Firehose client secret [deprecated]. Use client-secret").Default("admin").OverrideDefaultFromEnvar("FIREHOSE_PASSWORD").String()
+	client_id         = kingpin.Flag("client-id", "Firehose client id.").Default("admin").OverrideDefaultFromEnvar("FIREHOSE_CLIENT_ID").String()
+	client_secret     = kingpin.Flag("client-secret", "Firehose client secret.").Default("admin").OverrideDefaultFromEnvar("FIREHOSE_CLIENT_SECRET").String()
 	skipSSLValidation = kingpin.Flag("skip-ssl-validation", "Please don't").Default("false").OverrideDefaultFromEnvar("SKIP_SSL_VALIDATION").Bool()
 	debug             = kingpin.Flag("debug", "Enable debug mode. This disables forwarding to statsd and prints to stdout").Default("false").OverrideDefaultFromEnvar("DEBUG").Bool()
 )
@@ -38,6 +40,14 @@ func main() {
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
+	}
+
+	if *username == "admin" {
+		username = client_id
+        }
+
+        if *password == "admin" {
+		password = client_secret
 	}
 
 	tokenFetcher := &token.UAATokenFetcher{


### PR DESCRIPTION
Clarifies that the utility actually uses client id
and secret, not username and password.
Added command line options to match.
Also adds text to the readme to show syntax for using uaac to add the client id/secret.